### PR TITLE
Moved constant string to .rodata section.

### DIFF
--- a/Nat/Day_01/README.md
+++ b/Nat/Day_01/README.md
@@ -2,28 +2,27 @@
 
 - Language of choice: AArch64 Assembly.
 - Difficulty: Yes. (I'm a C# developer...)
-- Final binary size: `5888 bytes`.
+- Final binary size: `5896 bytes`.
 - Test hardware: Raspberry Pi 4.
 - Program runtime: `~4ms`.
 
 <!-- omit from toc -->
 ## Contents
 
-- [Advent of Code Day 1](#advent-of-code-day-1)
-  - [Requirements](#requirements)
-    - [Input Data](#input-data)
-      - [Input File Line Ending Modification](#input-file-line-ending-modification)
-    - [Linux](#linux)
-    - [QEMU User Space Emulator](#qemu-user-space-emulator)
-    - [Assembler and Linker](#assembler-and-linker)
-    - [**(Optional)** Debugger](#optional-debugger)
-    - [Just](#just)
-  - [Getting Started](#getting-started)
-  - [Debugging](#debugging)
-    - [Checking Return Codes](#checking-return-codes)
-    - [Viewing System Call Logs (QEMU)](#viewing-system-call-logs-qemu)
-    - [Building with Debug Information](#building-with-debug-information)
-    - [Using `gdb` to Display Variables](#using-gdb-to-display-variables)
+- [Requirements](#requirements)
+  - [Input Data](#input-data)
+    - [Input File Line Ending Modification](#input-file-line-ending-modification)
+  - [Linux](#linux)
+  - [QEMU User Space Emulator](#qemu-user-space-emulator)
+  - [Assembler and Linker](#assembler-and-linker)
+  - [**(Optional)** Debugger](#optional-debugger)
+  - [Just](#just)
+- [Getting Started](#getting-started)
+- [Debugging](#debugging)
+  - [Checking Return Codes](#checking-return-codes)
+  - [Viewing System Call Logs (QEMU)](#viewing-system-call-logs-qemu)
+  - [Building with Debug Information](#building-with-debug-information)
+  - [Using `gdb` to Display Variables](#using-gdb-to-display-variables)
 
 ## Requirements
 

--- a/Nat/Day_01/main.s
+++ b/Nat/Day_01/main.s
@@ -46,11 +46,7 @@
 .equ LINE_BUFFER_SIZE, 14   // Number of bytes per line (LF line endings).
 .equ PRINT_BUFFER_SIZE, 32  // The number of bytes to use as a print buffer.
 
-// -----------------------------------------------------------------------------
-// |                         Initialised "Static" Data                         |
-// -----------------------------------------------------------------------------
-
-.section .data
+.section .rodata
     // Align the data section to 16-byte boundaries.
     .align 4                // Align to 2^4 = 16 bytes.
     // The expected option to signify that the file name is being passed in to
@@ -84,6 +80,7 @@
 // -----------------------------------------------------------------------------
 // |                            Uninitialised Data                             |
 // -----------------------------------------------------------------------------
+
 .section .bss
     // Buffers are included in the .bss section to ensure they do not increase
     // the binary size, since they do not need to be initialised.


### PR DESCRIPTION
This has slightly increased the resulting binary size for some reason, but I think is more _technically_ correct to do.